### PR TITLE
存在しないツイートの情報にアクセスしようとした場合に、エラーハンドリングを行う

### DIFF
--- a/front/src/pages/tweet_detail.js
+++ b/front/src/pages/tweet_detail.js
@@ -10,6 +10,7 @@ import { Reply } from "../component/reply"
 import { ReplyPost } from "../component/reply_post"
 import { useNavigate } from "react-router-dom";
 import { UserIconGet } from "../api/icon_get"
+import {ErrorMessages} from '../shaerd/error'
 
 export const TweetDetail = () => {
 	const params = useParams();
@@ -43,10 +44,10 @@ export const TweetDetail = () => {
 				})
 				.catch((err) => {
 					switch (err.response.data) {
-						case 'Fail auth token':
+						case ErrorMessages.FailAuthToken:
 							navigate('/login');
 							break;
-						case 'record not found':
+						case ErrorMessages.RecordNotFound:
 							navigate('/not_found');
 							break;
 						default:

--- a/front/src/shaerd/error.js
+++ b/front/src/shaerd/error.js
@@ -1,0 +1,4 @@
+export const ErrorMessages = {
+    FailAuthToken: 'Fail auth token',
+    RecordNotFound: 'record not found'
+}; 


### PR DESCRIPTION
## 概要

存在しないツイートの情報にアクセスしようとした場合に、404ページにリダイレクトさせる

## 関連issue / PR

https://github.com/htoyoda18/TweetAppV2/issues/73