### PR TITLE
refactoring: エラーを定数として定義をしていたが、エラーとして定義する

### DIFF
--- a/api/handler/file.go
+++ b/api/handler/file.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -62,11 +61,11 @@ func (u file) IconGet(c *gin.Context) {
 	_, err = os.Stat(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			shared.Warn(LogVal("File", "IconGet", errors.New(shared.FailNotFound)))
+			shared.Warn(LogVal("File", "IconGet", shared.FailNotFound))
 			c.JSON(http.StatusBadRequest, err.Error())
 			return
 		}
-		shared.Error(LogVal("File", "IconGet", errors.New(shared.FailNotOpen)))
+		shared.Error(LogVal("File", "IconGet", shared.FailNotOpen))
 		c.JSON(http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/api/handler/like.go
+++ b/api/handler/like.go
@@ -38,7 +38,7 @@ func (l like) Add(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&params); err != nil {
 		shared.Warn(LogVal("Like", "Add", err))
-		err = errors.New(shared.ShouldBindJsonErr)
+		err = shared.ShouldBindJsonErr
 		c.JSON(http.StatusBadRequest, err.Error())
 		return
 	}

--- a/api/handler/reply.go
+++ b/api/handler/reply.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -32,7 +31,7 @@ func (r reply) Add(c *gin.Context) {
 	var params request.Reply
 	if err := c.ShouldBindJSON(&params); err != nil {
 		shared.Warn(LogVal("Reply", "Add", err))
-		err = errors.New(shared.ShouldBindJsonErr)
+		err = shared.ShouldBindJsonErr
 		c.JSON(http.StatusBadRequest, err.Error())
 		return
 	}

--- a/api/handler/tweet.go
+++ b/api/handler/tweet.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 
@@ -37,7 +36,7 @@ func (t tweet) Create(c *gin.Context) {
 	var params request.Tweet
 	if err := c.ShouldBindJSON(&params); err != nil {
 		shared.Warn(LogVal("Tweet", "Create", err))
-		err = errors.New(shared.ShouldBindJsonErr)
+		err = shared.ShouldBindJsonErr
 		c.JSON(http.StatusBadRequest, err.Error())
 		return
 	}

--- a/api/handler/user.go
+++ b/api/handler/user.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -42,6 +41,7 @@ func (u user) Create(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&params); err != nil {
 		shared.Warn(LogVal("User", "Create", err))
+		err = shared.ShouldBindJsonErr
 		c.JSON(http.StatusBadRequest, err.Error())
 		return
 	}
@@ -62,8 +62,8 @@ func (u user) Login(c *gin.Context) {
 	var params request.Login
 
 	if err := c.ShouldBindJSON(&params); err != nil {
-		err = errors.New(shared.ShouldBindJsonErr)
 		shared.Warn(LogVal("User", "Login", err))
+		err = shared.ShouldBindJsonErr
 		c.JSON(http.StatusBadRequest, err.Error())
 		return
 	}
@@ -92,7 +92,7 @@ func (u user) PasswordReset(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&params); err != nil {
 		shared.Warn(LogVal("User", "PasswordReset", err))
-		err = errors.New(shared.ShouldBindJsonErr)
+		err = shared.ShouldBindJsonErr
 		c.JSON(http.StatusBadRequest, err.Error())
 		return
 	}
@@ -114,7 +114,7 @@ func (u user) UpdatePassword(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&params); err != nil {
 		shared.Warn(LogVal("User", "UpdatePassword", err))
-		err = errors.New(shared.ShouldBindJsonErr)
+		err = shared.ShouldBindJsonErr
 		c.JSON(http.StatusBadRequest, err.Error())
 		return
 	}
@@ -144,7 +144,7 @@ func (u user) UpdateUser(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&params); err != nil {
 		shared.Warn(LogVal("User", "UpdatePassword", err))
-		err = errors.New(shared.ShouldBindJsonErr)
+		err = shared.ShouldBindJsonErr
 		c.JSON(http.StatusBadRequest, err.Error())
 		return
 	}

--- a/api/shared/auth.go
+++ b/api/shared/auth.go
@@ -1,7 +1,6 @@
 package shared
 
 import (
-	"errors"
 	"log"
 	"os"
 	"time"
@@ -34,20 +33,20 @@ func JwtParse(tokenString string) (int, error) {
 	var userID int
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			err := errors.New(FailToParse)
+			err := FailToParse
 			return "", err
 		}
 		return []byte(os.Getenv("JWTKEY")), nil
 	})
 	if err != nil {
-		log.Printf(FailToParse)
+		log.Println("FailToParse: ", FailToParse)
 		return 0, err
 	}
 
 	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
 		userID = int(claims["sub"].(float64))
 	} else {
-		log.Printf(FailAuthToken)
+		log.Println("FailToParse:", FailAuthToken)
 	}
 
 	return userID, nil
@@ -58,7 +57,7 @@ func AuthUser(c *gin.Context) (int, error) {
 	userID, err := JwtParse(cookie)
 	if err != nil {
 		log.Printf(err.Error())
-		return 0, errors.New(FailAuthToken)
+		return 0, FailAuthToken
 	}
 	return userID, nil
 }

--- a/api/shared/error.go
+++ b/api/shared/error.go
@@ -2,14 +2,15 @@ package shared
 
 import "errors"
 
-const UserNotFound = "User not found"
-const UserEmailDuplicate = "User email duplicate"
-const EmailNotFound = "Email not found"
-const FailAuthToken = "Fail auth token"
-const ShouldBindJsonErr = "Should bind JSON error"
-const FailToParse = "Fail To Parse"
-const FailNotFound = "Fail Not Found"
-const FailNotOpen = "Fail Not Open"
-const DuplicateLike = "Fail Duplicate Like"
-
-var ErrRecordNotFound = errors.New("record not found")
+var (
+	UserNotFound       = errors.New("User not found")
+	UserEmailDuplicate = errors.New("User email duplicate")
+	EmailNotFound      = errors.New("Email not found")
+	FailAuthToken      = errors.New("Fail auth token")
+	ShouldBindJsonErr  = errors.New("Should bind JSON error")
+	FailToParse        = errors.New("Fail To Parse")
+	FailNotFound       = errors.New("Fail Not Found")
+	FailNotOpen        = errors.New("Fail Not Open")
+	DuplicateLike      = errors.New("Fail Duplicate Like")
+	ErrRecordNotFound  = errors.New("record not found")
+)

--- a/api/usecase/like.go
+++ b/api/usecase/like.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"errors"
-
 	"github.com/htoyoda18/TweetAppV2/api/handler/request"
 	"github.com/htoyoda18/TweetAppV2/api/model"
 	"github.com/htoyoda18/TweetAppV2/api/repository"
@@ -38,7 +36,7 @@ func (l like) Add(params request.Like, userID int) error {
 		TweetID: params.TweetID,
 		UserID:  userID,
 	}, l.db); like != nil {
-		err := errors.New(shared.DuplicateLike)
+		err := shared.DuplicateLike
 		shared.Warn(LogVal("Like", "Add: Fail Duplicate Like", err))
 		return err
 	}

--- a/api/usecase/user.go
+++ b/api/usecase/user.go
@@ -42,7 +42,7 @@ func (u user) Create(params request.Signup) (*model.User, error) {
 
 	selectUser, _ := u.userRepository.Get(&model.User{Email: params.Email}, u.db)
 	if selectUser != nil {
-		err := errors.New(shared.UserEmailDuplicate)
+		err := shared.UserEmailDuplicate
 		shared.Warn(LogVal("User", "Create", err))
 		return nil, err
 	}
@@ -82,13 +82,13 @@ func (u user) Show(params request.Login) (*model.User, error) {
 	}, u.db)
 	if err != nil {
 		shared.Warn(LogVal("User", "Show", err))
-		err := errors.New(shared.UserNotFound)
+		err := shared.UserNotFound
 		return nil, err
 	}
 	err = shared.CompareHashAndPassword(user.Password, params.Password)
 	if err != nil {
 		shared.Warn(LogVal("User", "Show", err))
-		err := errors.New(shared.UserNotFound)
+		err := shared.UserNotFound
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ func (u user) PasswordReset(mail string) error {
 	}, u.db)
 	if err != nil {
 		shared.Warn(LogVal("User", "PasswordReset", err))
-		err := errors.New(shared.EmailNotFound)
+		err := shared.EmailNotFound
 		return err
 	}
 
@@ -135,7 +135,7 @@ func (u user) UpdatePassword(password string, userID int) error {
 		Password: hashPassword,
 	}, u.db)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		err := errors.New(shared.EmailNotFound)
+		err := shared.EmailNotFound
 		shared.Warn(LogVal("User", "UpdatePassword", err))
 		return err
 	} else if err != nil {


### PR DESCRIPTION
## 概要

shaerd/error.goで定義しているエラーを、文字列ではなくエラーとする

## 関連issue / PR

https://github.com/htoyoda18/TweetAppV2/issues/87