### PR TITLE
refactoring: APIのテストを行う際に、メールの送信もテスト出来るようにする

### DIFF
--- a/api/controller/handler/user_test.go
+++ b/api/controller/handler/user_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/htoyoda18/TweetAppV2/api/domain/model"
 	"github.com/htoyoda18/TweetAppV2/api/shared"
 	"github.com/htoyoda18/TweetAppV2/api/shared/test"
+	"github.com/htoyoda18/TweetAppV2/api/usecase"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 )
@@ -51,6 +52,8 @@ func TestUserCreate(t *testing.T) {
 			statusCode, result := test.APIClientForPost(tt.body, "signup")
 			if statusCode == 200 {
 				user, _ := test.UnmarshalJSONToStruct[model.User](result)
+				emailExists, _ := test.FindMailByToAndSubject(user.Email, usecase.SignUpSubject)
+				assert.Equal(t, true, emailExists)
 				assert.Equal(t, tt.body.Username, user.Name)
 				assert.Equal(t, tt.body.Email, user.Email)
 			} else {
@@ -120,7 +123,8 @@ func TestPasswordReset(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			statusCode, result := test.APIClientForPost(tt.body, "password_reset")
 			if statusCode == 200 {
-				//メールの検証が必要
+				emailExists, _ := test.FindMailByToAndSubject(tt.body.Email, usecase.PasswordRessetSubject)
+				assert.Equal(t, true, emailExists)
 			} else {
 				errMsg, _ := test.ReadErrorResponse(result)
 				assert.Equal(t, tt.responseError.Error(), errMsg)

--- a/api/docker-compose.test.yaml
+++ b/api/docker-compose.test.yaml
@@ -26,7 +26,7 @@ services:
     container_name: smtp_test
     image: mailhog/mailhog
     ports:
-      - "8026:8026"
+      - "8026:8025"
     networks:
       - backend_test
 

--- a/api/shared/test/mail.go
+++ b/api/shared/test/mail.go
@@ -60,10 +60,10 @@ func FindMailByToAndSubject(to string, subject usecase.MailSubject) (bool, error
 	return false, nil
 }
 
+var testMailhogUrl = fmt.Sprintf("http://localhost:8026/api/v2/messages")
+
 func GetAllMail() (*MailHogResponse, error) {
-	env, _ := shared.NewEnv()
-	domain := fmt.Sprintf("http://%s:%s", env.SmtpHost, "8025/api/v2/messages")
-	resp, err := http.Get(domain)
+	resp, err := http.Get(testMailhogUrl)
 	if err != nil {
 		shared.Error("failed to get mailhog", err)
 		return nil, err


### PR DESCRIPTION
## 概要

APIのテストを行う際に、メールの送信もテスト出来るようにする

## 関連issue / PR

https://github.com/htoyoda18/TweetAppV2/issues/178