### PR TITLE
ref: pagesディレクトリの直下には、ファイルを置かずにディレクトリを置いてページルーティングさせる

### DIFF
--- a/front/pages/404/index.tsx
+++ b/front/pages/404/index.tsx
@@ -1,7 +1,7 @@
 import { NextPage } from "next";
 import { useState, useEffect } from 'react';
 import Sidebar from '../../component/sidebar';
-import NotFoundStyle from '../css/not_found.module.css';
+import NotFoundStyle from '../../css/not_found.module.css';
 import { publicClient } from '../../api/client/axios'
 import { GetToken } from '../../shared/localStorage'
 import { useRouter } from 'next/router';

--- a/front/pages/404/index.tsx
+++ b/front/pages/404/index.tsx
@@ -1,12 +1,12 @@
 import { NextPage } from "next";
 import { useState, useEffect } from 'react';
-import Sidebar from '../component/sidebar';
+import Sidebar from '../../component/sidebar';
 import NotFoundStyle from '../css/not_found.module.css';
-import { publicClient } from '../api/client/axios'
-import { GetToken } from '../shared/localStorage'
+import { publicClient } from '../../api/client/axios'
+import { GetToken } from '../../shared/localStorage'
 import { useRouter } from 'next/router';
 import Head from 'next/head';
-import { url } from '../shared/url'
+import { url } from '../../shared/url'
 
 const NotFound: NextPage = () => {
     const token = GetToken();

--- a/front/pages/login/index.tsx
+++ b/front/pages/login/index.tsx
@@ -4,18 +4,18 @@ import { useRouter } from 'next/router';
 import LoginStyle from '../css/login.module.css';
 import IndexStyle from '../css/index.module.css';
 import sharedStyle from '../css/shared.module.css';
-import { TweetApp } from "../component/tweet_app";
-import { Note } from "../component/note";
-import { Formbtn } from "../component/form_btn";
-import { ErrorMsg } from "../component/error_message";
-import { ApiErrorMessages } from '../shared/error';
-import { UserLoginReqest } from '../api/type/user';
+import { TweetApp } from "../../component/tweet_app";
+import { Note } from "../../component/note";
+import { Formbtn } from "../../component/form_btn";
+import { ErrorMsg } from "../../component/error_message";
+import { ApiErrorMessages } from '../../shared/error';
+import { UserLoginReqest } from '../../api/type/user';
 import Head from 'next/head';
-import { FormField } from '../component/login_form_fileds'
-import { url } from '../shared/url'
-import { LoginPost } from '../api/client/login'
-import { ValidateToken } from '../api/client/validate_token'
-import { GetToken } from '../shared/localStorage';
+import { FormField } from '../../component/login_form_fileds'
+import { url } from '../../shared/url'
+import { LoginPost } from '../../api/client/login'
+import { ValidateToken } from '../../api/client/validate_token'
+import { GetToken } from '../../shared/localStorage';
 
 interface Errors {
     emailErr?: string;

--- a/front/pages/login/index.tsx
+++ b/front/pages/login/index.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import { NextPage } from "next";
 import { useRouter } from 'next/router';
-import LoginStyle from '../css/login.module.css';
-import IndexStyle from '../css/index.module.css';
-import sharedStyle from '../css/shared.module.css';
+import LoginStyle from '../../css/login.module.css';
+import IndexStyle from '../../css/index.module.css';
+import sharedStyle from '../../css/shared.module.css';
 import { TweetApp } from "../../component/tweet_app";
 import { Note } from "../../component/note";
 import { Formbtn } from "../../component/form_btn";

--- a/front/pages/password_reset/index.tsx
+++ b/front/pages/password_reset/index.tsx
@@ -1,15 +1,15 @@
 import { NextPage } from "next";
-import { TweetApp } from "../component/tweet_app"
+import { TweetApp } from "../../component/tweet_app"
 import PasswordResetStyle from '../css/password_reset.module.css';
-import { Formbtn } from "../component/form_btn"
+import { Formbtn } from "../../component/form_btn"
 import IndexStyle from '../css/index.module.css';
 import SharedStyle from '../css/shared.module.css';
 import { useState } from 'react';
-import { publicClient } from '../api/client/axios'
-import { ErrorMsg } from "../component/error_message"
-import { ApiErrorMessages } from '../shared/error'
+import { publicClient } from '../../api/client/axios'
+import { ErrorMsg } from "../../component/error_message"
+import { ApiErrorMessages } from '../../shared/error'
 import { useRouter } from 'next/router';
-import { PasswordResetReqest } from '../api/type/user';
+import { PasswordResetReqest } from '../../api/type/user';
 import Head from 'next/head';
 
 interface FormValues {

--- a/front/pages/password_reset/index.tsx
+++ b/front/pages/password_reset/index.tsx
@@ -1,9 +1,9 @@
 import { NextPage } from "next";
 import { TweetApp } from "../../component/tweet_app"
-import PasswordResetStyle from '../css/password_reset.module.css';
+import PasswordResetStyle from '../../css/password_reset.module.css';
 import { Formbtn } from "../../component/form_btn"
-import IndexStyle from '../css/index.module.css';
-import SharedStyle from '../css/shared.module.css';
+import IndexStyle from '../../css/index.module.css';
+import SharedStyle from '../../css/shared.module.css';
 import { useState } from 'react';
 import { publicClient } from '../../api/client/axios'
 import { ErrorMsg } from "../../component/error_message"

--- a/front/pages/password_reset_send/index.tsx
+++ b/front/pages/password_reset_send/index.tsx
@@ -1,7 +1,7 @@
 import { NextPage } from "next";
 import { TweetApp } from "../../component/tweet_app"
-import IndexStyle from '../css/index.module.css';
-import SharedStyle from '../css/shared.module.css';
+import IndexStyle from '../../css/index.module.css';
+import SharedStyle from '../../css/shared.module.css';
 import PasswordResetSendStyle from '../css/password_reset_send.module.css';
 import Head from 'next/head';
 

--- a/front/pages/password_reset_send/index.tsx
+++ b/front/pages/password_reset_send/index.tsx
@@ -1,5 +1,5 @@
 import { NextPage } from "next";
-import { TweetApp } from "../component/tweet_app"
+import { TweetApp } from "../../component/tweet_app"
 import IndexStyle from '../css/index.module.css';
 import SharedStyle from '../css/shared.module.css';
 import PasswordResetSendStyle from '../css/password_reset_send.module.css';

--- a/front/pages/signup/index.tsx
+++ b/front/pages/signup/index.tsx
@@ -1,18 +1,18 @@
 import { NextPage } from "next";
 import { useState } from 'react';
-import { publicClient } from '../api/client/axios'
+import { publicClient } from '../../api/client/axios'
 import SignUpStyle from '../css/signup.module.css';
 import { useRouter } from 'next/router'
 import sharedStyle from '../css/shared.module.css';
-import { TweetApp } from "../component/tweet_app"
-import { Note } from "../component/note"
-import { Formbtn } from "../component/form_btn"
-import { ErrorMsg } from "../component/error_message"
+import { TweetApp } from "../../component/tweet_app"
+import { Note } from "../../component/note"
+import { Formbtn } from "../../component/form_btn"
+import { ErrorMsg } from "../../component/error_message"
 import IndexStyle from '../css/index.module.css';
-import { ApiErrorMessages } from '../shared/error'
-import { SignupReqest } from '../api/type/user'
+import { ApiErrorMessages } from '../../shared/error'
+import { SignupReqest } from '../../api/type/user'
 import Head from 'next/head';
-import { url } from '../shared/url'
+import { url } from '../../shared/url'
 
 interface FomrErrors {
     emailErr?: string;

--- a/front/pages/signup/index.tsx
+++ b/front/pages/signup/index.tsx
@@ -1,14 +1,14 @@
 import { NextPage } from "next";
 import { useState } from 'react';
 import { publicClient } from '../../api/client/axios'
-import SignUpStyle from '../css/signup.module.css';
+import SignUpStyle from '../../css/signup.module.css';
 import { useRouter } from 'next/router'
-import sharedStyle from '../css/shared.module.css';
+import sharedStyle from '../../css/shared.module.css';
 import { TweetApp } from "../../component/tweet_app"
 import { Note } from "../../component/note"
 import { Formbtn } from "../../component/form_btn"
 import { ErrorMsg } from "../../component/error_message"
-import IndexStyle from '../css/index.module.css';
+import IndexStyle from '../../css/index.module.css';
 import { ApiErrorMessages } from '../../shared/error'
 import { SignupReqest } from '../../api/type/user'
 import Head from 'next/head';

--- a/front/pages/tweet/index.tsx
+++ b/front/pages/tweet/index.tsx
@@ -1,8 +1,8 @@
 import { NextPage } from "next";
 import { useState } from 'react';
 import Sidebar from '../../component/sidebar'
-import TweetStyle from '../css/tweet.module.css';
-import sharedStyle from '../css/shared.module.css';
+import TweetStyle from '../../css/tweet.module.css';
+import sharedStyle from '../../css/shared.module.css';
 import { privateClient } from '../../api/client/axios'
 import { useRouter } from 'next/router'
 import { ApiErrorMessages } from '../../shared/error'

--- a/front/pages/tweet/index.tsx
+++ b/front/pages/tweet/index.tsx
@@ -1,13 +1,13 @@
 import { NextPage } from "next";
 import { useState } from 'react';
-import Sidebar from '../component/sidebar'
+import Sidebar from '../../component/sidebar'
 import TweetStyle from '../css/tweet.module.css';
 import sharedStyle from '../css/shared.module.css';
-import { privateClient } from '../api/client/axios'
+import { privateClient } from '../../api/client/axios'
 import { useRouter } from 'next/router'
-import { ApiErrorMessages } from '../shared/error'
-import { TweetReqest } from '../api/type/tweet'
-import { useCheckToken } from '../libs/hook/check_token';
+import { ApiErrorMessages } from '../../shared/error'
+import { TweetReqest } from '../../api/type/tweet'
+import { useCheckToken } from '../../libs/hook/check_token';
 import Head from 'next/head';
 
 const Tweet: NextPage = () => {


### PR DESCRIPTION
## 概要

pagesディレクトリの直下には、ファイルを置かずにディレクトリを置いてページルーティングさせる

## 関連issue / PR

https://github.com/htoyoda18/TweetAppV2/issues/203